### PR TITLE
Use capture time as header's timestamp

### DIFF
--- a/src/camera_nodelet.cpp
+++ b/src/camera_nodelet.cpp
@@ -459,10 +459,20 @@ ifm3d_ros::CameraNodelet::Run()
           continue;
         }
 
+      last_frame = ros::Time::now();
+
       std_msgs::Header head = std_msgs::Header();
-      head.stamp = ros::Time::now();
       head.frame_id = this->frame_id_;
-      last_frame = head.stamp;
+      head.stamp = ros::Time(
+        std::chrono::duration_cast<std::chrono::duration<double, std::ratio<1>>>
+        (this->im_->TimeStamp().time_since_epoch()).count());
+      if (ros::Time::now() - head.stamp > ros::Duration(60.0))
+        {
+          ROS_WARN_ONCE("Camera's time is not up to date, therefore header's "
+            "timestamps will be the reception time and not capture time. "
+            "Please update the camera's time if you need the capture time.");
+          head.stamp = ros::Time::now();
+        }
 
       std_msgs::Header optical_head = std_msgs::Header();
       optical_head.stamp = head.stamp;


### PR DESCRIPTION
We have multiple cameras and we needed a way to know if frames are in sync or not. So we put the frame timestamp in headers of published cloud.

To keep backward compatibility and avoid publishing a very outdated timestamp on systems where the camera time is not up to date, we check if the frame time is less than 60 seconds old. (Hopping that a 60 seconds latency will never be reached). If we cannot use the camera timestamp we use `ros::Time::now()` and warn once.

I saw you talked about this feature on #6. I don't know if you wanted to integrate it like that. Feel free to tell me the way you wanted it to be done, if this doesn’t suit you.