### PR TITLE
Remove added substring from point cloud frame_id

### DIFF
--- a/launch/nodelet.launch
+++ b/launch/nodelet.launch
@@ -112,7 +112,7 @@
   <node pkg="tf2_ros"
         type="static_transform_publisher"
         name="$(arg camera)_tf"
-        args="0 0 0 -1.5707963267948966 0 -1.5707963267948966 $(arg frame_id_base)_link $(arg frame_id_base)_optical_link"
+        args="0 0 0 -1.5707963267948966 0 -1.5707963267948966 $(arg frame_id_base) $(arg frame_id_base)_optical_link"
         respawn="$(arg respawn)" />
 
 </launch>

--- a/src/camera_nodelet.cpp
+++ b/src/camera_nodelet.cpp
@@ -97,7 +97,7 @@ ifm3d_ros::CameraNodelet::onInit()
   this->xmlrpc_port_ = static_cast<std::uint16_t>(xmlrpc_port);
   this->schema_mask_ = static_cast<std::uint16_t>(schema_mask);
 
-  this->frame_id_ = frame_id_base + "_link";
+  this->frame_id_ = frame_id_base;
   this->optical_frame_id_ = frame_id_base + "_optical_link";
 
   //-------------------


### PR DESCRIPTION
Currently the driver sets the `frame_id` of the published point cloud equal to the specified `frame_id_base` parameter plus the substring `_link`. The `nodelet.launch` file then creates a static transform publisher from this link to the optical frame. This is problematic when using the IFM in the context of an existing URDF (i.e. IFM mounted to a robot):
- The point cloud gets published relative to a frame that is unlikely to exist since a somewhat arbitrary sub-string is appended to the user's input
- The [static transform publisher in `nodelet.launch`](https://github.com/ifm/ifm3d-ros/blob/36850c79b987985b45132f86a2b615da6913924e/launch/nodelet.launch#L112-L116) creates a disconnected TF tree because the parent frame with the appended substring is unlikely to already exist

These issues result in both visualization errors in Rviz and transformation errors when using TF to transform the cloud.

This PR changes the driver and launch file to use the specified `frame_id_base` parameter directly as the `frame_id` of the point cloud itself. This change resolves the two issues described above and maintains the current functionality in the case that the IFM is launched by itself.

